### PR TITLE
Refactor image pair layout to CSS grid

### DIFF
--- a/src/components/App.css
+++ b/src/components/App.css
@@ -331,6 +331,51 @@ img {
 
 }
 
+.pair-grid {
+  width: 100%;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 1rem;
+}
+
+.pair-card {
+  display: flex;
+  gap: 0.75rem;
+  padding: 0.5rem;
+  border-radius: 18px;
+  background-color: rgba(255, 255, 255, 0.04);
+  transition: background-color .2s ease, transform .2s ease;
+  touch-action: manipulation;
+}
+
+.pair-card:hover,
+.pair-card:focus-visible {
+  background-color: rgba(255, 255, 255, 0.08);
+  text-decoration: none;
+}
+
+.pair-card:focus-visible {
+  box-shadow: 0 0 0 3px rgba(255, 248, 255, 0.4);
+}
+
+.pair-thumb {
+  flex: 1;
+  display: flex;
+  justify-content: center;
+}
+
+@media (max-width: 600px) {
+  .pair-grid {
+    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+    gap: 0.85rem;
+  }
+
+  .pair-card {
+    gap: 0.5rem;
+    padding: 0.5rem;
+  }
+}
+
 .btn {
   background-color: #604760;
   color: #eee0e0;

--- a/src/components/App.css
+++ b/src/components/App.css
@@ -338,24 +338,35 @@ img {
   gap: 1rem;
 }
 
+@media (min-width: 992px) {
+  .pair-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
 .pair-card {
   display: flex;
   gap: 0.75rem;
   padding: 0.5rem;
   border-radius: 18px;
-  background-color: rgba(255, 255, 255, 0.04);
-  transition: background-color .2s ease, transform .2s ease;
+  background-color: transparent;
+  transition: transform .2s ease, box-shadow .2s ease;
   touch-action: manipulation;
 }
 
 .pair-card:hover,
 .pair-card:focus-visible {
-  background-color: rgba(255, 255, 255, 0.08);
+  box-shadow: 0 12px 30px rgba(0, 0, 0, 0.35),
+    0 0 0 2px rgba(255, 248, 255, 0.1),
+    0 12px 25px rgba(96, 71, 96, 0.35);
+  transform: translateY(-2px);
   text-decoration: none;
 }
 
 .pair-card:focus-visible {
-  box-shadow: 0 0 0 3px rgba(255, 248, 255, 0.4);
+  box-shadow: 0 0 0 3px rgba(255, 248, 255, 0.4),
+    0 12px 30px rgba(0, 0, 0, 0.35),
+    0 12px 25px rgba(96, 71, 96, 0.35);
 }
 
 .pair-thumb {

--- a/src/components/App.css
+++ b/src/components/App.css
@@ -331,23 +331,25 @@ img {
 
 }
 
+
 .pair-grid {
   width: 100%;
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
-  gap: 1rem;
+  gap: 0.75rem;
 }
 
 @media (min-width: 992px) {
   .pair-grid {
     grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 0.85rem;
   }
 }
 
 .pair-card {
   display: flex;
-  gap: 0.75rem;
-  padding: 0.5rem;
+  gap: 0.5rem;
+  padding: 0.35rem;
   border-radius: 18px;
   background-color: transparent;
   transition: transform .2s ease, box-shadow .2s ease;
@@ -375,15 +377,36 @@ img {
   justify-content: center;
 }
 
+.pair-thumb .mm-imgwrap {
+  margin: 0.2rem;
+}
+
 @media (max-width: 600px) {
   .pair-grid {
     grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
-    gap: 0.85rem;
+    gap: 0.6rem;
   }
 
   .pair-card {
-    gap: 0.5rem;
-    padding: 0.5rem;
+    gap: 0.4rem;
+    padding: 0.3rem;
+  }
+}
+
+.pagination {
+  gap: 0.35rem;
+}
+
+.pagination .page-link {
+  padding: 0.4rem 0.75rem;
+  border-radius: 999px;
+  font-size: 0.95rem;
+}
+
+@media (max-width: 600px) {
+  .pagination .page-link {
+    padding: 0.35rem 0.65rem;
+    font-size: 0.9rem;
   }
 }
 

--- a/src/components/App.css
+++ b/src/components/App.css
@@ -401,6 +401,10 @@ img {
   padding: 0.4rem 0.75rem;
   border-radius: 999px;
   font-size: 0.95rem;
+  background-color: #fef8ff;
+  color: #604760;
+  border: none;
+  box-shadow: 0 0 0 1px rgba(254, 248, 255, 0.5);
 }
 
 @media (max-width: 600px) {
@@ -408,6 +412,20 @@ img {
     padding: 0.35rem 0.65rem;
     font-size: 0.9rem;
   }
+}
+
+.pagination .page-item.active .page-link,
+.pagination .page-item.active .page-link:focus,
+.pagination .page-item.active .page-link:hover {
+  background-color: transparent;
+  color: #fef8ff;
+  box-shadow: 0 0 0 1px rgba(254, 248, 255, 0.85);
+}
+
+.pagination .page-link:focus,
+.pagination .page-link:hover {
+  color: #fef8ff;
+  box-shadow: 0 0 0 1px rgba(254, 248, 255, 0.75);
 }
 
 .btn {

--- a/src/components/ImagePairs.jsx
+++ b/src/components/ImagePairs.jsx
@@ -223,12 +223,12 @@ export default function ImagePairs({ handleClick }) {
       </Helmet>
 
       <div className="container">
-        <div className="pair-grid">
-          {pageItems.map((pair, pairIndex) => (
-            <PairCard
-              pair={pair}
-              handleClick={handleClick}
-              key={`pair-${pairIndex}-${pair.title || ""}`}
+      <div className="pair-grid">
+        {pageItems.map((pair, pairIndex) => (
+          <PairCard
+            pair={pair}
+            handleClick={handleClick}
+            key={`pair-${pairIndex}-${pair.title || ""}`}
             />
           ))}
         </div>
@@ -349,7 +349,7 @@ function MMImage({ src, tiny, alt }) {
 
   return (
     <div className="pair-thumb">
-      <div className="mm-imgwrap m-1">
+      <div className="mm-imgwrap">
         {!loaded && (
           <div
             className="mm-skel"

--- a/src/components/ImagePairs.jsx
+++ b/src/components/ImagePairs.jsx
@@ -158,12 +158,6 @@ export default function ImagePairs({ handleClick }) {
     return { totalPages: pages, page: safePage, pageItems: items };
   }, [state.allPairs, pageFromUrl]);
 
-  const columns = useMemo(() => {
-    const cols = [[], [], []];
-    pageItems.forEach((pair, idx) => cols[idx % 3].push(pair));
-    return cols;
-  }, [pageItems]);
-
   const goTo = (n) => {
     const clamped = Math.min(Math.max(n, 1), totalPages || 1);
     const next = new URLSearchParams(searchParams);
@@ -229,17 +223,13 @@ export default function ImagePairs({ handleClick }) {
       </Helmet>
 
       <div className="container">
-        <div className="row">
-          {columns.map((col, colIndex) => (
-            <div className="col-md-4" key={`col-${colIndex}`}>
-              {col.map((pair, pairIndex) => (
-                <PairCard
-                  pair={pair}
-                  handleClick={handleClick}
-                  key={`pair-${colIndex}-${pairIndex}-${pair.title || ""}`}
-                />
-              ))}
-            </div>
+        <div className="pair-grid">
+          {pageItems.map((pair, pairIndex) => (
+            <PairCard
+              pair={pair}
+              handleClick={handleClick}
+              key={`pair-${pairIndex}-${pair.title || ""}`}
+            />
           ))}
         </div>
 
@@ -325,7 +315,7 @@ function PairCard({ pair, handleClick }) {
   return (
     <a
       href={hrefStr}
-      className="row text-decoration-none gx-0"
+      className="pair-card text-decoration-none"
       role="button"
       aria-label={`${pair.title} - open preview`}
       onClick={openAsModal}
@@ -358,7 +348,7 @@ function MMImage({ src, tiny, alt }) {
   const [loaded, setLoaded] = useState(false);
 
   return (
-    <div className="col-6 d-flex justify-content-center">
+    <div className="pair-thumb">
       <div className="mm-imgwrap m-1">
         {!loaded && (
           <div


### PR DESCRIPTION
## Summary
- replace the three-column bootstrap layout with a responsive CSS grid for image pairs
- add grid and card styling to keep square thumbnails with comfortable spacing and tap targets on small screens
- retain pagination behavior while keeping the existing skeleton loaders and rounded borders

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692646df7e3c832e827a68449dcd3544)