### PR TITLE
Add social media buttons and fix lint warnings

### DIFF
--- a/src/components/App.css
+++ b/src/components/App.css
@@ -24,6 +24,50 @@ body,
   flex-direction: column;
 }
 
+.social-links {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  align-items: center;
+  gap: 0.75rem;
+  margin: 0.5rem 0 1.25rem;
+}
+
+.social-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  padding: 0.45rem 0.9rem;
+  border-radius: 999px;
+  background: #604760;
+  color: #fef8ff;
+  font-family: "Nunito", sans-serif;
+  font-size: 0.95rem;
+  line-height: 1.2;
+  transition: transform .15s ease, box-shadow .15s ease, background-color .15s ease, color .15s ease;
+  box-shadow: 0 10px 22px rgba(0, 0, 0, 0.25);
+}
+
+.social-button:hover,
+.social-button:focus-visible {
+  background: #eee0e0;
+  color: #604760;
+  transform: translateY(-1px);
+  box-shadow: 0 12px 26px rgba(0, 0, 0, 0.3);
+  text-decoration: none;
+}
+
+.social-button:focus-visible {
+  outline: 2px solid #eee0e0;
+  outline-offset: 3px;
+}
+
+.social-button svg {
+  width: 20px;
+  height: 20px;
+  fill: currentColor;
+}
+
 #main {
   width: 100%;
   display: flex;
@@ -219,6 +263,21 @@ nav {
     margin-top: 1.75rem;
     padding: 0 1rem;
     width: 100%;
+  }
+
+  .social-links {
+    gap: 0.5rem;
+    margin: 0.5rem 0 1rem;
+  }
+
+  .social-button {
+    padding: 0.4rem 0.8rem;
+    font-size: 0.9rem;
+  }
+
+  .social-button svg {
+    width: 18px;
+    height: 18px;
   }
 
   nav {

--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -13,6 +13,39 @@ const HOLIDAYS = [
   { key: "halloween", label: "Halloween" },
 ];
 
+const SOCIAL_LINKS = [
+  {
+    key: "instagram",
+    label: "Instagram",
+    href: "https://www.instagram.com/matchmadepics",
+    icon: (
+      <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+        <path d="M7 3h10a4 4 0 0 1 4 4v10a4 4 0 0 1-4 4H7a4 4 0 0 1-4-4V7a4 4 0 0 1 4-4zm0 2a2 2 0 0 0-2 2v10a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2V7a2 2 0 0 0-2-2H7zm11.25 1.25a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0zM12 8a4 4 0 1 1 0 8 4 4 0 0 1 0-8zm0 2a2 2 0 1 0 0 4 2 2 0 0 0 0-4z" />
+      </svg>
+    ),
+  },
+  {
+    key: "tiktok",
+    label: "TikTok",
+    href: "https://www.tiktok.com/@matchmadepics",
+    icon: (
+      <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+        <path d="M16 3.5v2.4a4.6 4.6 0 0 0 3.1 1.2v2.6a6.6 6.6 0 0 1-3.1-.75v5.35a5.75 5.75 0 1 1-5.75-5.75c.21 0 .42.01.63.04v2.65a2.75 2.75 0 1 0 2.25 2.7V3.5H16z" />
+      </svg>
+    ),
+  },
+  {
+    key: "kofi",
+    label: "Ko-fi",
+    href: "https://ko-fi.com/matchmade",
+    icon: (
+      <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+        <path d="M5 6h11.5a3.5 3.5 0 0 1 0 7H15a4 4 0 0 1-4 4H7a2 2 0 0 1-2-2V6zm2 2v8h2a2 2 0 0 0 2-2V8H7zm9.5 0H15v3h1.5a1.5 1.5 0 0 0 0-3z" />
+      </svg>
+    ),
+  },
+];
+
 function SeasonalMenu() {
   const [open, setOpen] = useState(false);
   const navigate = useNavigate();
@@ -101,6 +134,21 @@ function App() {
         <p className="sub-title">
           Matching profile pictures for friends or special someone.
         </p>
+
+        <div className="social-links" aria-label="MatchMade social profiles">
+          {SOCIAL_LINKS.map((link) => (
+            <a
+              key={link.key}
+              className="social-button"
+              href={link.href}
+              target="_blank"
+              rel="noreferrer noopener"
+            >
+              {link.icon}
+              <span>{link.label}</span>
+            </a>
+          ))}
+        </div>
 
         <nav aria-label="Categories">
           <div className="category-row">

--- a/src/pages/PairPage.jsx
+++ b/src/pages/PairPage.jsx
@@ -3,7 +3,7 @@
 // - Renders both images so crawlers can index them.
 // - Emits per-pair <title>, description, canonical, and (optional) OG/Twitter.
 
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useState } from "react";
 import { Link, useParams } from "react-router-dom";
 import { Helmet } from "@dr.pogodin/react-helmet";
 import { cldUrl } from "@/libs/cdn";

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,6 +1,9 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import path from 'path'
+import { fileURLToPath } from 'url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
 export default defineConfig({
   plugins: [react()],


### PR DESCRIPTION
## Summary
- add Instagram, TikTok, and Ko-fi buttons to the header with inline icons and hover/focus states
- tune styling for the social buttons on desktop and mobile
- clean up existing lint issues in PairPage and the Vite config

## Testing
- npm run lint


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69263b630164832ea352153db6c7b4ca)