### PR TITLE
Optimize image loading and offscreen rendering for mobile

### DIFF
--- a/src/components/App.css
+++ b/src/components/App.css
@@ -532,6 +532,8 @@ img {
   background-color: transparent;
   transition: transform .2s ease, box-shadow .2s ease;
   touch-action: manipulation;
+  content-visibility: auto;
+  contain-intrinsic-size: 240px 240px;
 }
 
 .pair-card:hover,

--- a/src/components/ImagePairs.jsx
+++ b/src/components/ImagePairs.jsx
@@ -9,7 +9,7 @@ import {
 import { Helmet } from "@dr.pogodin/react-helmet";
 import { slugify } from "@/utils/slug";
 import NotFound from "./NotFound";
-import { cldUrl } from "../libs/cdn";
+import { cldSrcSet, cldUrl } from "../libs/cdn";
 import { analytics } from "@/libs/analytics";
 
 const PAIRS_PER_PAGE = 6;
@@ -320,6 +320,7 @@ export default function ImagePairs({ handleClick }) {
                 <PairCard
                   pair={pair}
                   handleClick={handleClick}
+                  pairIndex={pairIndex}
                   key={`pair-${pairIndex}-${pair.title || ""}`}
                 />
               ))}
@@ -378,7 +379,7 @@ export default function ImagePairs({ handleClick }) {
 
 /* ===== Pair & Thumb components ===== */
 
-function PairCard({ pair, handleClick }) {
+function PairCard({ pair, handleClick, pairIndex }) {
   const params = useParams();
   const routeFolder = (params.category || "home").toLowerCase();
 
@@ -388,6 +389,7 @@ function PairCard({ pair, handleClick }) {
 
   const slug = slugify(pair.title);
   const dims = { w: 420, h: 420, fit: "fill", g: "auto" };
+  const srcSetWidths = [220, 320, 420, 560];
   const navigate = useNavigate();
   const location = useLocation();
 
@@ -425,6 +427,8 @@ function PairCard({ pair, handleClick }) {
       {pair.imageSet.map((img, index) => {
         const isCloud = !!img.publicId;
         const fullSrc = isCloud ? cldUrl(img.publicId, dims) : img.url;
+        const srcSet = isCloud ? cldSrcSet(img.publicId, srcSetWidths, dims) : undefined;
+        const sizes = "(max-width: 900px) 50vw, 33vw";
 
         const side = index === 0 ? "left" : "right";
         const alt =
@@ -433,7 +437,10 @@ function PairCard({ pair, handleClick }) {
           <MMImage
             key={(img.publicId || img.url || "") + index}
             src={fullSrc}
+            srcSet={srcSet}
+            sizes={srcSet ? sizes : undefined}
             alt={alt}
+            priority={pairIndex === 0}
           />
         );
       })}
@@ -441,7 +448,7 @@ function PairCard({ pair, handleClick }) {
   );
 }
 
-function MMImage({ src, alt }) {
+function MMImage({ src, srcSet, sizes, alt, priority = false }) {
   const [loaded, setLoaded] = useState(false);
 
   return (
@@ -450,10 +457,13 @@ function MMImage({ src, alt }) {
         {!loaded && <div className="mm-skel" />}
         <img
           src={src}
+          srcSet={srcSet}
+          sizes={sizes}
           alt={alt}
           className={loaded ? "is-loaded" : ""}
-          loading="lazy"
+          loading={priority ? "eager" : "lazy"}
           decoding="async"
+          fetchPriority={priority ? "high" : "auto"}
           onLoad={() => setLoaded(true)}
         />
       </div>

--- a/src/components/ImagePairs.jsx
+++ b/src/components/ImagePairs.jsx
@@ -388,7 +388,7 @@ function PairCard({ pair, handleClick, pairIndex }) {
 
 
   const slug = slugify(pair.title);
-  const dims = { w: 420, h: 420, fit: "fill", g: "auto" };
+  const dims = { w: 420, h: 420, fit: "fit", g: "auto" }; // no crop
   const srcSetWidths = [220, 320, 420, 560];
   const navigate = useNavigate();
   const location = useLocation();
@@ -429,7 +429,8 @@ function PairCard({ pair, handleClick, pairIndex }) {
         const fullSrc = isCloud ? cldUrl(img.publicId, dims) : img.url;
         const srcSet = isCloud ? cldSrcSet(img.publicId, srcSetWidths, dims) : undefined;
         const sizes =
-          "(min-width: 1200px) 320px, (min-width: 900px) 30vw, (min-width: 600px) 45vw, 48vw";
+  "(min-width: 1200px) 180px, (min-width: 900px) 170px, (min-width: 600px) 24vw, 24vw";
+
 
         const side = index === 0 ? "left" : "right";
         const alt =

--- a/src/components/ImagePairs.jsx
+++ b/src/components/ImagePairs.jsx
@@ -428,7 +428,8 @@ function PairCard({ pair, handleClick, pairIndex }) {
         const isCloud = !!img.publicId;
         const fullSrc = isCloud ? cldUrl(img.publicId, dims) : img.url;
         const srcSet = isCloud ? cldSrcSet(img.publicId, srcSetWidths, dims) : undefined;
-        const sizes = "(max-width: 900px) 50vw, 33vw";
+        const sizes =
+          "(min-width: 1200px) 320px, (min-width: 900px) 30vw, (min-width: 600px) 45vw, 48vw";
 
         const side = index === 0 ? "left" : "right";
         const alt =
@@ -440,7 +441,7 @@ function PairCard({ pair, handleClick, pairIndex }) {
             srcSet={srcSet}
             sizes={srcSet ? sizes : undefined}
             alt={alt}
-            priority={pairIndex === 0}
+            priority={pairIndex < 2}
           />
         );
       })}


### PR DESCRIPTION
### Motivation
- Improve mobile performance by reducing unnecessary network and rendering work for image thumbnails.
- Ensure the first visible pair loads with higher priority for faster perceived load time.
- Reduce offscreen rendering cost for card grid to lower CPU/GPU work on mobile devices.

### Description
- Add responsive Cloudinary `srcset`/`sizes` by importing and using `cldSrcSet` and passing `srcSet`/`sizes` to thumbnail images.
- Introduce a `pairIndex` prop and `priority` flag to eager-load and set `fetchPriority` for the first pair's images.
- Update `MMImage` to accept `srcSet`, `sizes`, and `priority` and use `loading={priority ? "eager" : "lazy"}`.
- Enable CSS-level optimization on cards by adding `content-visibility: auto` and `contain-intrinsic-size: 240px 240px` to `.pair-card` in `App.css`.

### Testing
- Started the dev server using `npm run dev` which reported Vite ready and succeeded.
- Ran a Playwright script to load the homepage at a mobile viewport and capture a screenshot, which completed and produced an artifact.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6954c0f13af8832ebaa8e47b553e9d81)