### PR TITLE
Adjust responsive image sizes hint in PairCard

### DIFF
--- a/src/components/ImagePairs.jsx
+++ b/src/components/ImagePairs.jsx
@@ -413,6 +413,8 @@ function PairCard({ pair, handleClick }) {
     }
   };
 
+  const sizes = "(max-width: 640px) 50vw, 33vw";
+
   return (
     <a
       href={hrefStr}
@@ -434,6 +436,7 @@ function PairCard({ pair, handleClick }) {
             key={(img.publicId || img.url || "") + index}
             src={fullSrc}
             alt={alt}
+            sizes={sizes}
           />
         );
       })}
@@ -441,7 +444,7 @@ function PairCard({ pair, handleClick }) {
   );
 }
 
-function MMImage({ src, alt }) {
+function MMImage({ src, alt, sizes }) {
   const [loaded, setLoaded] = useState(false);
 
   return (
@@ -451,6 +454,7 @@ function MMImage({ src, alt }) {
         <img
           src={src}
           alt={alt}
+          sizes={sizes}
           className={loaded ? "is-loaded" : ""}
           loading="lazy"
           decoding="async"


### PR DESCRIPTION
### Motivation
- Prevent oversized desktop image selections by keeping the desktop/default hint at the original column width while only changing the mobile breakpoint.
- Make a single shared `sizes` hint per pair so both sides use the same responsive width guidance.

### Description
- Added a `sizes` constant in `PairCard` set to `(max-width: 640px) 50vw, 33vw` to adjust only the mobile breakpoint and keep desktop at `33vw`.
- Passed the `sizes` prop through to `MMImage` and forwarded it to the underlying `<img>` element.
- Modified `src/components/ImagePairs.jsx` to accept and propagate the new `sizes` prop and left all other behavior unchanged.

### Testing
- Started the dev server with `npm run dev` and the Vite server started successfully.
- Ran a Playwright script to load the page and capture a screenshot, which completed and produced `artifacts/image-pairs.png`.
- No automated test failures were observed during these runs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6959ce034014832e824ec253869664f3)